### PR TITLE
Allow zstr to build on VS2013.

### DIFF
--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -6,6 +6,12 @@
 #include <cstring>
 #include <string>
 
+#ifndef _MSC_VER
+#define NOEXCEPT noexcept
+#else
+#define NOEXCEPT
+#endif
+
 /**
  * This namespace defines wrappers for std::ifstream, std::ofstream, and
  * std::fstream objects. The wrappers perform the following steps:
@@ -23,7 +29,7 @@ class Exception
 {
 public:
     Exception(const std::string& msg) : _msg(msg) {}
-    const char * what() const noexcept { return _msg.c_str(); }
+    const char * what() const NOEXCEPT { return _msg.c_str(); }
 private:
     std::string _msg;
 }; // class Exception
@@ -60,7 +66,7 @@ struct static_method_holder
         {
             if (mode & mode_val_v[i])
             {
-                res += (not res.empty()? "|" : "");
+                res += (!res.empty()? "|" : "");
                 res += mode_name_v[i];
             }
         }
@@ -69,15 +75,15 @@ struct static_method_holder
     }
     static void check_mode(const std::string& filename, std::ios_base::openmode mode)
     {
-        if ((mode & std::ios_base::trunc) and not (mode & std::ios_base::out))
+        if ((mode & std::ios_base::trunc) && !(mode & std::ios_base::out))
         {
             throw Exception(std::string("strict_fstream: open('") + filename + "'): mode error: trunc and not out");
         }
-        else if ((mode & std::ios_base::app) and not (mode & std::ios_base::out))
+        else if ((mode & std::ios_base::app) && !(mode & std::ios_base::out))
         {
             throw Exception(std::string("strict_fstream: open('") + filename + "'): mode error: app and not out");
         }
-        else if ((mode & std::ios_base::trunc) and (mode & std::ios_base::app))
+        else if ((mode & std::ios_base::trunc) && (mode & std::ios_base::app))
         {
             throw Exception(std::string("strict_fstream: open('") + filename + "'): mode error: trunc and app");
         }
@@ -162,7 +168,7 @@ public:
     }
     void open(const std::string& filename, std::ios_base::openmode mode = std::ios_base::in)
     {
-        if (not (mode & std::ios_base::out)) mode |= std::ios_base::in;
+        if (!(mode & std::ios_base::out)) mode |= std::ios_base::in;
         exceptions(std::ios_base::badbit);
         detail::static_method_holder::check_mode(filename, mode);
         std::fstream::open(filename, mode);

--- a/src/strict_fstream.hpp
+++ b/src/strict_fstream.hpp
@@ -6,10 +6,10 @@
 #include <cstring>
 #include <string>
 
-#ifndef _MSC_VER
-#define NOEXCEPT noexcept
-#else
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define NOEXCEPT
+#else
+#define NOEXCEPT noexcept
 #endif
 
 /**

--- a/src/zstr.hpp
+++ b/src/zstr.hpp
@@ -123,7 +123,7 @@ public:
 
     istreambuf(const istreambuf &) = delete;
     istreambuf & operator = (const istreambuf &) = delete;
-#ifndef _WIN32
+#if !(defined(_MSC_VER) && _MSC_VER < 1900)
     istreambuf(istreambuf &&) = default;
     istreambuf & operator = (istreambuf &&) = default;
 #endif
@@ -242,7 +242,7 @@ public:
 
     ostreambuf(const ostreambuf &) = delete;
     ostreambuf & operator = (const ostreambuf &) = delete;
-#ifndef _WIN32
+#if !(defined(_MSC_VER) && _MSC_VER < 1900)
     ostreambuf(ostreambuf &&) = default;
     ostreambuf & operator = (ostreambuf &&) = default;
 #endif


### PR DESCRIPTION
- noexcept is not supported.
- MSVC doesn't have great support for iso646 logical operators, so just
  remove them.
- Automatically generated move constructors and assignment operators
  are not supported.
